### PR TITLE
Regex version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 itest/nexus/keystore.jks
+.idea

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Deploys and retrieve artifacts from a Maven Repository Manager.
       -----END CERTIFICATE-----
     ```
 
+* `version_regexp`: *Optional.* You can set a regex to follow specific versions like: `1.*` or `1.2.*`
 
 ## Behavior
 

--- a/assets/check
+++ b/assets/check
@@ -36,7 +36,7 @@ repository_cert=$(jq -r '.source.repository_cert //empty' < $payload)
 
 # TODO: Add more error checking
 if [ -z "$release_url" ] && [ -z "$snapshot_url" ] ; then
-  echo "[ERROR] invalid payload (must specify url or snapshot_url)"
+  printf '\e[91m[ERROR]\e[0m invalid payload (must specify url)\n'
   exit 1
 fi
 
@@ -71,11 +71,14 @@ else
   metadataUrl="$url/${groupId//.//}/$artifactId/maven-metadata.xml"
 fi
 
-metadata=$(curl --fail --silent --show-error $cert $auth $metadataUrl)
+set +e
+metadata=$(curl --fail --silent --show-error $cert $auth $metadataUrl 2>&1)
 if [ $? -ne 0 ]; then
-  echo "[ERROR] failed to download maven-metadata.xml from: $metadataUrl"
+  printf '\e[91m[ERROR]\e[0m %s\n' "$metadata"
+  printf '\e[91m[ERROR]\e[0m failed to download maven-metadata.xml from: %s\n' "$metadataUrl"
   exit 2
 fi
+set -e
 
 declare -a versions=( )
 if [[ "$version" = *-SNAPSHOT ]]; then

--- a/assets/check
+++ b/assets/check
@@ -25,14 +25,15 @@ if [ "$debug" = "true" ]; then
   set -x
 fi
 
-release_url=$(jq -r '.source.url //empty' < $payload)
-snapshot_url=$(jq -r '.source.snapshot_url //empty' < $payload)
-artifact=$(jq -r '.source.artifact //empty' < $payload)
-version=$(jq -r '.version.version //empty' < $payload)
-username=$(jq -r '.source.username //empty' < $payload)
-password=$(jq -r '.source.password //empty' < $payload)
-skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < $payload)
-repository_cert=$(jq -r '.source.repository_cert //empty' < $payload)
+release_url=$(jq -r '.source.url //empty' < ${payload})
+snapshot_url=$(jq -r '.source.snapshot_url //empty' < ${payload})
+artifact=$(jq -r '.source.artifact //empty' < ${payload})
+version_regexp=$(jq -r '.source.version_regexp // "none"' < ${payload})
+version=$(jq -r '.version.version //empty' < ${payload})
+username=$(jq -r '.source.username //empty' < ${payload})
+password=$(jq -r '.source.password //empty' < ${payload})
+skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < ${payload})
+repository_cert=$(jq -r '.source.repository_cert //empty' < ${payload})
 
 # TODO: Add more error checking
 if [ -z "$release_url" ] && [ -z "$snapshot_url" ] ; then
@@ -41,9 +42,9 @@ if [ -z "$release_url" ] && [ -z "$snapshot_url" ] ; then
 fi
 
 # groupId:artifactId:type[:classifier]
-groupId=$(get_group_id $artifact)
-artifactId=$(get_artifact_id $artifact)
-packaging=$(get_packaging $artifact)
+groupId=$(get_group_id ${artifact})
+artifactId=$(get_artifact_id ${artifact})
+packaging=$(get_packaging ${artifact})
 
 auth=""
 [ -n "$username" ] && auth="--user $username:$password"
@@ -52,15 +53,15 @@ cert=""
 if [ "$skip_cert_check" = "true" ]; then
   cert="-k"
 elif [ -n "$repository_cert" ]; then
-  mkdir -p $working/security
-  echo "$repository_cert" > $working/security/repository.crt
+  mkdir -p ${working}/security
+  echo "$repository_cert" > ${working}/security/repository.crt
   cert="--cacert $working/security/repository.crt"
 fi
 
 # convert 1.0.0-20170328.031519-19 to 1.0.0-SNAPSHOT
 uniqueVersion=$(echo "$version" | grep -oE "[0-9]{8}\.[0-9]{6}-[0-9]{1,}" || true)
 if [ -n "$uniqueVersion" ]; then
-  version=$(echo ${version%-$uniqueVersion}-SNAPSHOT)
+  version=$(echo ${version%-${uniqueVersion}}-SNAPSHOT)
 fi
 
 url=$release_url
@@ -82,21 +83,29 @@ set -e
 
 declare -a versions=( )
 if [[ "$version" = *-SNAPSHOT ]]; then
-  versions[1]=$(echo $metadata | xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='$packaging']/value/text()" - 2>/dev/null)
+  versions[1]=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='$packaging']/value/text()" - 2>/dev/null)
 elif [ "$version" = "latest" ] || [ -z "$version" ]; then
-  versions[1]=$(echo $metadata | xmllint --xpath "/metadata/versioning/versions/version[last()]/text()" - 2>/dev/null)
+  versions[1]=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/versions/version[last()]/text()" - 2>/dev/null)
 else
-  itemsCount=$(echo $metadata | xmllint --xpath 'count(/metadata/versioning/versions/version)' - 2>/dev/null)
+  itemsCount=$(echo ${metadata} | xmllint --xpath 'count(/metadata/versioning/versions/version)' - 2>/dev/null)
   found=false
   for (( i=1; i <= $itemsCount; i++ )); do
-
-    current=$(echo $metadata | xmllint --xpath "/metadata/versioning/versions/version[$i]/text()" - 2>/dev/null)
-    if [ "$found" = false ] && [ "$current" = "$version" ]; then
-      found=true
+    current=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/versions/version[$i]/text()" - 2>/dev/null)
+    echo "VERSION CURRENT $current"
+    echo "VERSION REGEXP $version_regexp"
+    if [ "$found" = false ]; then
+      if [ "$current" = "$version" ] || [[ "$current" =~ $version_regexp ]]; then
+        found=true
+      fi
     fi
 
+    echo "FOUND $found"
+
     if [ "$found" = true ]; then
-      versions[$i]=$current
+      versions[$i]=${current}
+      if [ "$version_regexp" != "none" ]; then
+        found=false
+      fi
     fi
   done
 fi

--- a/assets/check
+++ b/assets/check
@@ -25,15 +25,15 @@ if [ "$debug" = "true" ]; then
   set -x
 fi
 
-release_url=$(jq -r '.source.url //empty' < ${payload})
-snapshot_url=$(jq -r '.source.snapshot_url //empty' < ${payload})
-artifact=$(jq -r '.source.artifact //empty' < ${payload})
-version_regexp=$(jq -r '.source.version_regexp // "none"' < ${payload})
-version=$(jq -r '.version.version //empty' < ${payload})
-username=$(jq -r '.source.username //empty' < ${payload})
-password=$(jq -r '.source.password //empty' < ${payload})
-skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < ${payload})
-repository_cert=$(jq -r '.source.repository_cert //empty' < ${payload})
+release_url=$(jq -r '.source.url //empty' < $payload)
+snapshot_url=$(jq -r '.source.snapshot_url //empty' < $payload)
+artifact=$(jq -r '.source.artifact //empty' < $payload)
+version_regexp=$(jq -r '.source.version_regexp //empty' < $payload)
+version=$(jq -r '.version.version //empty' < $payload)
+username=$(jq -r '.source.username //empty' < $payload)
+password=$(jq -r '.source.password //empty' < $payload)
+skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < $payload)
+repository_cert=$(jq -r '.source.repository_cert //empty' < $payload)
 
 # TODO: Add more error checking
 if [ -z "$release_url" ] && [ -z "$snapshot_url" ] ; then
@@ -42,9 +42,9 @@ if [ -z "$release_url" ] && [ -z "$snapshot_url" ] ; then
 fi
 
 # groupId:artifactId:type[:classifier]
-groupId=$(get_group_id ${artifact})
-artifactId=$(get_artifact_id ${artifact})
-packaging=$(get_packaging ${artifact})
+groupId=$(get_group_id $artifact)
+artifactId=$(get_artifact_id $artifact)
+packaging=$(get_packaging $artifact)
 
 auth=""
 [ -n "$username" ] && auth="--user $username:$password"
@@ -53,15 +53,15 @@ cert=""
 if [ "$skip_cert_check" = "true" ]; then
   cert="-k"
 elif [ -n "$repository_cert" ]; then
-  mkdir -p ${working}/security
-  echo "$repository_cert" > ${working}/security/repository.crt
+  mkdir -p $working/security
+  echo "$repository_cert" > $working/security/repository.crt
   cert="--cacert $working/security/repository.crt"
 fi
 
 # convert 1.0.0-20170328.031519-19 to 1.0.0-SNAPSHOT
 uniqueVersion=$(echo "$version" | grep -oE "[0-9]{8}\.[0-9]{6}-[0-9]{1,}" || true)
 if [ -n "$uniqueVersion" ]; then
-  version=$(echo ${version%-${uniqueVersion}}-SNAPSHOT)
+  version=$(echo ${version%-$uniqueVersion}-SNAPSHOT)
 fi
 
 url=$release_url
@@ -84,26 +84,26 @@ set -e
 declare -a versions=( )
 if [[ "$version" = *-SNAPSHOT ]]; then
   versions[1]=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='$packaging']/value/text()" - 2>/dev/null)
-elif [ "$version" = "latest" ] || [ -z "$version" ]; then
+elif [ "$version" = "latest" ] || [ -z "$version" -a -z "$version_regexp" ]; then
   versions[1]=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/versions/version[last()]/text()" - 2>/dev/null)
 else
   itemsCount=$(echo ${metadata} | xmllint --xpath 'count(/metadata/versioning/versions/version)' - 2>/dev/null)
   found=false
   for (( i=1; i <= $itemsCount; i++ )); do
     current=$(echo ${metadata} | xmllint --xpath "/metadata/versioning/versions/version[$i]/text()" - 2>/dev/null)
-    echo "VERSION CURRENT $current"
-    echo "VERSION REGEXP $version_regexp"
     if [ "$found" = false ]; then
-      if [ "$current" = "$version" ] || [[ "$current" =~ $version_regexp ]]; then
+      if [ "$current" = "$version" ]; then
         found=true
+      elif [ -n "$version_regexp" ]; then
+        if [[ "$current" =~ $version_regexp ]]; then
+          found=true
+        fi
       fi
     fi
 
-    echo "FOUND $found"
-
     if [ "$found" = true ]; then
       versions[$i]=${current}
-      if [ "$version_regexp" != "none" ]; then
+      if [ -n "$version_regexp" ]; then
         found=false
       fi
     fi

--- a/assets/in
+++ b/assets/in
@@ -103,6 +103,30 @@ $resource_dir/mvnw dependency:copy $args
 
 jq -n \
 --arg version "$version" \
+--arg groupId "$groupId" \
+--arg artifactId "$artifactId" \
+--arg packaging "$packaging" \
+--arg url "$url" \
 '{
-  version: {version: $version}
+  version: $version,
+  groupId: $groupId,
+  artifactId: $artifactId,
+  packaging: $packaging,
+  url: $url
+ }' > $destination/$artifactId-$version.json
+
+jq -n \
+--arg version "$version" \
+--arg groupId "$groupId" \
+--arg artifactId "$artifactId" \
+--arg packaging "$packaging" \
+--arg url "$url" \
+'{
+  version: {version: $version},
+  metadata: [
+  { "name": "groupId", "value": $groupId },
+  { "name": "artifactId", "value": $artifactId },
+  { "name": "packaging", "value": $packaging },
+  { "name": "url", "value": $url }
+  ]
 }' >&3

--- a/test/check.sh
+++ b/test/check.sh
@@ -95,7 +95,60 @@ it_can_check_latest_from_three_versions() {
   '
 }
 
+it_can_check_regexp_from_three_versions() {
+
+  local src=$(mktemp -d $TMPDIR/check-src.XXXXXX)
+
+  local repository=$src/remote-repository
+  mkdir -p $repository
+
+  local url=file://$repository
+  local artifact=ci.concourse.maven:maven-resource:jar:standalone
+
+  local version1=$(deploy_artifact $url $artifact '1.1.' $src)
+  local version2=$(deploy_artifact $url $artifact '4.4.4' $src)
+  local version3=$(deploy_artifact $url $artifact '4.10.4' $src)
+
+  check_artifact_regex $url $artifact "4.4.*" $src | \
+  jq -e \
+  --arg version $version2 \
+  '
+    . == [
+      {version: $version}
+    ]
+  '
+}
+
+
+it_can_check_regexp_minor_from_patches() {
+
+  local src=$(mktemp -d $TMPDIR/check-src.XXXXXX)
+
+  local repository=$src/remote-repository
+  mkdir -p $repository
+
+  local url=file://$repository
+  local artifact=ci.concourse.maven:maven-resource:jar:standalone
+
+  local version1=$(deploy_artifact $url $artifact '1.1.0' $src)
+  local version2=$(deploy_artifact $url $artifact '4.4.4' $src)
+  local version3=$(deploy_artifact $url $artifact '4.4.5' $src)
+
+  check_artifact_regex $url $artifact "4.4.*" $src | \
+  jq -e \
+  --arg version2 $version2 \
+  --arg version3 $version3 \
+  '
+    . == [
+      {version: $version2},
+      {version: $version3}
+    ]
+  '
+}
+
 run it_can_check_from_one_version
 run it_can_check_from_three_versions
 run it_can_check_latest_from_one_version
 run it_can_check_latest_from_three_versions
+run it_can_check_regexp_from_three_versions
+run it_can_check_regexp_minor_from_patches

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -154,6 +154,26 @@ check_artifact() {
   }' | $resource_dir/check "$src" | tee /dev/stderr
 }
 
+
+check_artifact_regex() {
+  local url=$1
+  local artifact=$2
+  local regex=$3
+  local src=$4
+
+  jq -n \
+  --arg url "$url" \
+  --arg artifact "$artifact" \
+  --arg regex "$regex" \
+  '{
+    source: {
+      url: $url,
+      artifact: $artifact,
+      version_regexp: $regex
+    }
+  }' | $resource_dir/check "$src" | tee /dev/stderr
+}
+
 check_artifact_from_manager() {
 
   local version=$1


### PR DESCRIPTION
Adds `version_regexp` parameter to resource definition to be able to emit only the matching versions.

Can be used like this:
```
resources:
- name: artifact
  type: maven-resource
  source:
    url: https://myrepo.example.com/repository/maven-releases/
    artifact: com.example:example-webapp:jar
    version_regexp: "1.*"
```

The resource will emit all the new `1.x` versions and skip the others